### PR TITLE
Fix bounds indices

### DIFF
--- a/scripts/generate_pdal_pipelines.py
+++ b/scripts/generate_pdal_pipelines.py
@@ -36,7 +36,7 @@ def parse_args():
 def create_pipeline(leaf_id, polygon, urls, args):
     content = []
     b = polygon.bounds
-    bounds = ([b[0], b[1]], [b[2], b[3]])
+    bounds = ([b[0], b[2]], [b[1], b[3]])
 
     for url in urls:
         tile = {}


### PR DESCRIPTION
**(More detail in the opened issue)**

PDAL expects bounds to have the following format:  [ x_min, x_max ], [ y_min, y_max ]

However, Geopandas returns bounds in the following form:  [ x_min, y_min ], [ x_max, y_max ]

Geopandas boundaries were mistakenly entered into PDAL as they were, without index adjustment. As a result, the LiDAR tiles are much larger than necessary, which increases calculation time. The code has therefore been corrected:

bounds = ([b[0], **b[1]]**, [**b[2]**, b[3]])
to:
bounds = ([b[0], **b[2]**], [**b[1]**, b[3]])